### PR TITLE
feat: send property images and forward leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The project follows a modular architecture for clarity and maintainability:
     TWILIO_ACCOUNT_SID=your_account_sid
     TWILIO_AUTH_TOKEN=your_auth_token
     TWILIO_PHONE_NUMBER=your_twilio_whatsapp_number
+    LEAD_NOTIFICATION_NUMBER=realtor_number_to_receive_leads
 
     # Redis Configuration
     REDIS_HOST=your_redis_host
@@ -82,7 +83,8 @@ The `startup.sh` script is configured to run the application using Gunicorn. Azu
 ## Key Features
 
 -   **Modular Design**: Easy to understand, maintain, and extend.
--   **Lead Detection**: A dedicated module analyzes user intent to identify potential customers.
+-   **Lead Detection**: A dedicated module analyzes user intent to identify potential customers and forwards leads to a configured number.
+-   **Property Photos**: Image links in responses are automatically sent as WhatsApp images.
 -   **RAG (Retrieval-Augmented Generation)**: Uses a FAISS vector store to provide answers based on your specific property data.
 -   **Session Management**: Uses Redis to maintain conversation history and prevent processing duplicate messages.
--   **Centralized Configuration**: All settings are managed in one place. 
+-   **Centralized Configuration**: All settings are managed in one place.

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ class Settings:
     TWILIO_ACCOUNT_SID = os.environ.get('TWILIO_ACCOUNT_SID')
     TWILIO_AUTH_TOKEN = os.environ.get('TWILIO_AUTH_TOKEN')
     TWILIO_PHONE_NUMBER = os.environ.get('TWILIO_PHONE_NUMBER')
+    LEAD_NOTIFICATION_NUMBER = os.environ.get('LEAD_NOTIFICATION_NUMBER')
 
     # Redis Configuration
     REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")

--- a/core/lead_detector.py
+++ b/core/lead_detector.py
@@ -34,29 +34,29 @@ class LeadDetector:
     @staticmethod
     def _create_lead_detection_prompt(message: str) -> str:
         return f"""
-        Analyze the following user message from a real estate chat.
-        Your task is to determine if the user is expressing a clear intent to buy, rent, or schedule a visit for a property.
+        Analiza el siguiente mensaje del usuario en un chat inmobiliario.
+        Tu tarea es determinar si el usuario expresa una intención clara de comprar, rentar o agendar una visita a una propiedad.
 
-        Respond ONLY with a JSON object in the following format:
+        Responde SOLO con un objeto JSON en el siguiente formato:
         {{
-            "is_lead": boolean,
+            "is_lead": booleano,
             "interest": "buy" | "rent" | "visit" | "inquiry" | "none",
             "property_mentions": ["property_name_1", "property_name_2"]
         }}
 
-        - "is_lead": true if the user shows concrete interest (e.g., "I want to see it", "I'm interested in buying", "Can we schedule a visit?"). False for general questions or greetings.
-        - "interest": 
-            - "buy": User wants to purchase.
-            - "rent": User wants to rent.
-            - "visit": User explicitly asks to see a property.
-            - "inquiry": User is asking specific questions about a property but hasn't committed to a visit/purchase yet.
-            - "none": No interest shown (e.g., "hello", "thank you").
-        - "property_mentions": A list of any specific property names or addresses mentioned in the message.
+        - "is_lead": verdadero si el usuario muestra interés concreto (por ejemplo, "quiero verlo", "estoy interesado en comprar", "podemos agendar una visita?"). Falso para preguntas generales o saludos.
+        - "interest":
+            - "buy": el usuario quiere comprar.
+            - "rent": el usuario quiere rentar.
+            - "visit": el usuario pide explícitamente ver una propiedad.
+            - "inquiry": el usuario hace preguntas específicas pero aún no se compromete a visitar/comprar.
+            - "none": no hay interés mostrado (por ejemplo, "hola", "gracias").
+        - "property_mentions": lista de nombres o direcciones de propiedades mencionadas en el mensaje.
 
-        User Message: "{message}"
+        Mensaje del usuario: "{message}"
 
-        JSON Response:
+        Respuesta JSON:
         """
 
 # Singleton instance
-lead_detector = LeadDetector(llm_chain) 
+lead_detector = LeadDetector(llm_chain)

--- a/core/llm_chain.py
+++ b/core/llm_chain.py
@@ -106,13 +106,16 @@ class LLMChain:
     @staticmethod
     def _get_qa_prompt():
         return ChatPromptTemplate.from_messages([
-            ("system", "You are an expert real estate assistant for 'Apolo'. "
-                       "Your goal is to help users find properties and organize visits. "
-                       "Be friendly, professional, and concise. "
-                       "Use the following context to answer the user's question. "
-                       "If the information is not in the context, say you don't have that detail and offer to help in other ways. "
-                       "Do not make up information.\n\n"
-                       "Context:\n{context}"),
+            (
+                "system",
+                "Eres un asistente experto en bienes raíces para 'Apolo'. "
+                "Tu objetivo es ayudar a los usuarios a encontrar propiedades y organizar visitas. "
+                "Sé amable, profesional y conciso. "
+                "Utiliza el siguiente contexto para responder a la pregunta del usuario. "
+                "Si la información no está en el contexto, indica que no la tienes y ofrece otras formas de ayudar. "
+                "No inventes información.\n\n"
+                "Contexto:\n{context}"
+            ),
             ("user", "{input}"),
         ])
 
@@ -130,7 +133,7 @@ class LLMChain:
             "chat_history": chat_history
         })
         
-        answer = response.get("answer", "I'm sorry, I encountered an issue and can't respond right now.")
+        answer = response.get("answer", "Lo siento, tuve un problema y no puedo responder en este momento.")
         
         # Добавляем текущий диалог в Redis-backed память
         self.add_message_to_memory(session_id, question, answer)
@@ -139,4 +142,4 @@ class LLMChain:
         return answer
 
 # Singleton instance
-llm_chain = LLMChain() 
+llm_chain = LLMChain()

--- a/core/logic.py
+++ b/core/logic.py
@@ -1,9 +1,11 @@
 import logging
+import re
 from utils.redis_client import redis_client
 from utils.twilio_client import twilio_client
 from core.llm_chain import llm_chain
 from core.lead_detector import lead_detector
 from core.smart_router import smart_router
+from config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -37,21 +39,24 @@ def process_message(from_number: str, message_body: str, message_sid: str):
         # Обычный режим с использованием памяти чата
         bot_response = llm_chain.invoke_chain(message_body, from_number)
 
-    # 5. Send the response back to the user
-    twilio_client.send_whatsapp_message(from_number, bot_response)
+    # 5. Extract image URLs and send the response back to the user
+    image_urls = re.findall(r'https?://\S+\.(?:png|jpg|jpeg)', bot_response, flags=re.IGNORECASE)
+    text_response = re.sub(r'https?://\S+\.(?:png|jpg|jpeg)', '', bot_response, flags=re.IGNORECASE).strip()
+    twilio_client.send_whatsapp_message(from_number, text_response or ' ', media_urls=image_urls or None)
 
     logger.info(f"Response sent to {from_number}")
 
 
 def handle_lead(user_number: str, lead_data: dict):
-    """
-    Handles a detected lead.
-    (For now, it just logs the event. Later, it can send emails, save to CRM, etc.)
-    """
+    """Handles a detected lead."""
     logger.info(f"LEAD DETECTED for user {user_number}!")
     logger.info(f"Lead Details: {lead_data}")
-    
-    # Example of a special response for a lead
+
+    realtor_number = settings.LEAD_NOTIFICATION_NUMBER
+    if realtor_number:
+        lead_message = f"Nuevo lead de {user_number}: {lead_data}"
+        twilio_client.send_whatsapp_message(realtor_number, lead_message)
+
     interest = lead_data.get("interest")
     if interest == "visit":
         twilio_client.send_whatsapp_message(
@@ -62,4 +67,4 @@ def handle_lead(user_number: str, lead_data: dict):
         twilio_client.send_whatsapp_message(
             user_number,
             "¡Perfecto! Gracias por tu interés. Un asesor te contactará pronto para darte más información."
-        ) 
+        )

--- a/utils/twilio_client.py
+++ b/utils/twilio_client.py
@@ -12,17 +12,18 @@ class TwilioClient:
         self.client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
         self.from_number = f'whatsapp:{settings.TWILIO_PHONE_NUMBER}'
 
-    def send_whatsapp_message(self, to_number: str, body: str):
-        """
-        Sends a WhatsApp message to a specified number.
-        """
+    def send_whatsapp_message(self, to_number: str, body: str, media_urls: list[str] | None = None):
+        """Sends a WhatsApp message and optional media to a specified number."""
         try:
-            to_number_formatted = f'whatsapp:{to_number}'
-            message = self.client.messages.create(
-                from_=self.from_number,
-                body=body,
-                to=to_number_formatted
-            )
+            to_number_formatted = f"whatsapp:{to_number}"
+            params = {
+                "from_": self.from_number,
+                "body": body,
+                "to": to_number_formatted,
+            }
+            if media_urls:
+                params["media_url"] = media_urls
+            message = self.client.messages.create(**params)
             logger.info(f"Message sent to {to_number}: SID {message.sid}")
             return True
         except Exception as e:
@@ -30,4 +31,4 @@ class TwilioClient:
             return False
 
 # Singleton instance
-twilio_client = TwilioClient() 
+twilio_client = TwilioClient()


### PR DESCRIPTION
## Summary
- отправка изображений недвижимости через WhatsApp, если в ответе бота есть ссылки
- пересылка информации о лидах на указанный номер
- промпты и обнаружение лида переведены на испанский; обновлена документация

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68925810be0c8332ac73874d720d562a